### PR TITLE
Allow eeUtil to interact with multiple storage buckets in the same account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.3.0 - 2021-05-13
+
+### fixed
+
+### changed
+- Storage operations can take a bucket as an optional parameter instead of always using the default.
+- Storage operations will try to authenticate with default environment credentials the first time they are called.
+
+
 ## v0.2.3 - 2021-02-05
 
 ### fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ eeUtil.downloadAsset('mycollection/myasset')
 
 __Install__
 
-`pip install -e git+https://github.com/fgassert/eeUtil.git#egg=eeUtil`
+`pip install eeUtil`
 
 __Develop__
 

--- a/eeUtil/gsbucket.py
+++ b/eeUtil/gsbucket.py
@@ -7,106 +7,140 @@ from . import eeutil
 # see https://github.com/googleapis/google-api-python-client/issues/299
 logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
 
-# Unary bucket object
+# Unary client object
+_gsClient = None
 _gsBucket = None
 
+
 def init(bucket=None, project=None, credentials=None):
-    '''Initalize google cloud storage bucket'''
+    '''Initialize Google Cloud Storage client and default bucket
+    
+    Args:
+        bucket (str): Default bucket to use
+        project (str): Authenticate to this GCP project
+        credentials (google.auth.credentials.Credentials): OAuth credentials
+    '''
+    global _gsClient
     global _gsBucket
-    if not bucket:
-        bucket = _getDefaultBucket()
-        logging.warning('No bucket provided, attempting to use default {}'.format(bucket))
-    gsClient = storage.Client(project, credentials=credentials) if project else storage.Client(credentials=credentials)
-    _gsBucket = gsClient.bucket(bucket)
-    if not _gsBucket.exists():
-        logging.info('Bucket {} does not exist, creating'.format(bucket))
-        _gsBucket.create()
+    _gsClient = storage.Client(project, credentials=credentials) if project else storage.Client(credentials=credentials)
+    if bucket:
+        _gsBucket = _gsClient.bucket(bucket)
+        if not _gsBucket.exists():
+            logging.info('Bucket gs://{bucket} does not exist, creating')
+            _gsBucket.create()
 
 
-def _getDefaultBucket():
-    '''Generate new bucket name'''
-    return 'eeutil-{}'.format(hash(eeutil.getHome()))
+def Client():
+    '''Returns Google Cloud Storage client'''
+    if not _gsClient:
+        init()
+    return _gsClient
 
 
-def getName():
-    '''Returns bucket name'''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
+def Bucket(bucket=None):
+    '''Returns authenticated Bucket object'''
+    bucket = _defaultBucketName(bucket)
+    return Client().bucket(bucket)
+
+
+def _defaultBucketName(bucket=None):
+    '''Returns default bucket name if bucket is None'''
+    if bucket is not None:
+        return bucket
+    if _gsBucket is None:
+        raise Exception('No default bucket, run eeUtil.init() to set a default bucket')
     return _gsBucket.name
 
 
 def asURI(path, bucket=None):
     '''Returns blob path as URI'''
-    if bucket is None:
-        bucket = getName()
-    return f"gs://{bucket}/{path}"
+    bucket = _defaultBucketName(bucket)
+    return f"gs://{os.path.join(bucket, path)}"
 
 
-def isURI(path):
-    '''Returns true if path is valid URI for this bucket'''
-    min_len = len(getName()) + 5
-    return len(path) > min_len and path[:min_len] == f'gs://{getName()}'
+def isURI(path, bucket=''):
+    '''Returns true if path is valid URI for bucket'''
+    start = f'gs://{bucket}'
+    return (
+        len(path) > len(start)+2 
+        and path[:len(start)] == start
+        and path[len(start)+1:].find('/') > -1
+    )
 
 
 def pathFromURI(uri):
     '''Returns blob path from URI'''
-    if isURI(uri):
-        return uri[6 + len(getName()):]
-    else:
-        raise Exception(f'Path {uri} does not match gs://{getName()}/<blob>')
+    return fromUri(uri)[1]
 
 
-def stage(files, prefix=''):
-    '''Upload files to GS with prefix'''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
+def fromUri(uri):
+    '''Returns bucket name and blob path from URI'''
+    if not isURI(uri):
+        raise Exception(f'Path {uri} does not match gs://<bucket>/<blob>')
+    return uri[6:].split('/', 1)
+
+
+def stage(files, prefix='', bucket=None):
+    '''Upload files to GCS
+
+    Uploads files to gs://<bucket>/<prefix>/<filename>
+
+    Args:
+        files (list, str): Filenames of local files to upload
+        prefix (str): Folder to upload to (prepended to file name)
+        bucket (str): GCS bucket to upload to
+
+    Returns:
+        list: URIs of uploaded files
+    '''
 
     files = (files,) if isinstance(files, str) else files
     gs_uris = []
     for f in files:
         path = os.path.join(prefix, os.path.basename(f))
-        uri = asURI(path)
+        uri = asURI(path, bucket)
         logging.debug(f'Uploading {f} to {uri}')
-        _gsBucket.blob(path).upload_from_filename(f)
+        Bucket(bucket).blob(path).upload_from_filename(f)
         gs_uris.append(uri)
     return gs_uris
 
 
 def remove(gs_uris):
     '''
-    Remove blobs from GS
+    Remove blobs from GCS
 
-    `gs_uris` must be full paths `gs://<bucket>/<blob>`
+    Args:
+        gs_uris (list, str): Full paths to blob(s) to remove `gs://<bucket>/<blob>`
     '''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
-
     gs_uris = (gs_uris,) if isinstance(gs_uris, str) else gs_uris
-    paths = []
-    for uri in gs_uris:
-        paths.append(pathFromURI(uri))
 
-    logging.debug(f"Deleting {paths} from gs://{getName()}")    
-    # on_error null function to ignore NotFound
-    _gsBucket.delete_blobs(paths, lambda x:x)
+    paths = {}
+    for uri in gs_uris:
+        bucket, path = fromUri(uri)
+        if bucket in paths:
+            paths[bucket].append(path)
+        else:
+            paths[bucket] = [path]
+
+    for bucket, paths in paths:
+        logging.debug(f"Deleting {paths} from gs://{bucket}")
+        Bucket(bucket).delete_blobs(paths, on_error=lambda x:x)
 
 
 def download(gs_uri, filename=None, directory=None):
     '''
-    Download blob from GS
+    Download blob from GCS
 
-    `gs_uri` must be full path `gs://<bucket>/<blob>`
-    `filename` name of local file to save defaults to remote name
-    `directory` save files to directory
+    Args:
+        gs_uri (string): full path to blob `gs://<bucket>/<blob>`
+        filename (string): name of local file to save (default: blob name)
+        directory (string): local directory to save files to
     '''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
-
     if filename is None:
         filename = os.path.basename(gs_uri)
     if directory is not None:
         filename = os.path.join(directory, filename)
-
-    path = pathFromURI(gs_uri)
-    logging.debug(f"Downloading gs://{path}")
-    _gsBucket.blob(path).download_to_filename(filename)
+    
+    bucket, path = fromURI(gs_uri)
+    logging.debug(f"Downloading {gs_uri}")
+    Bucket(bucket).blob(path).download_to_filename(filename)


### PR DESCRIPTION
Storage operations can take a bucket as an optional parameter instead of always using the default
Storage operations will try to authenticate with default environment credentials the first time they are called