### PR TITLE
Improve pathing to `earthengine-public` assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.0 - 2021-05-13
 
 ### fixed
+- Paths starting with `/` are assumed to be `earthengine-public` assets if no project is specified.
 
 ### changed
 - Storage operations can take a bucket as an optional parameter instead of always using the default.


### PR DESCRIPTION
Public assets in the EarthEngine catalog don't follow the standard naming scheme for IDs, omitting the `projects/earthengine-public/assets` prefix. This can cause unexpected issues with certain cloud api functions. 

This patch makes eeUtil prepend the `projects/earthengine-public/assets` prefix to paths starting with `/` that aren't followed by a project.