### PR TITLE
Version 0.3.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 ### added
 - Add `tree` function to recursively list assets in folder
 - Add `export`, `exportImage`, and `exportTable` to export assets to cloud storage
+- Add `saveImage` and `findOrSaveImage` to export or cache images as assets
 
 ### changed
-- Update `download` to work for image collections
+- Update `download` to work for feature collections
 - Update `download` to be able to recursively download image collections
 - Storage operations can take a bucket as an optional parameter instead of always using the default.
 - Storage operations will try to authenticate with default environment credentials the first time they are called.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.0 - 2021-05-13
 
 ### fixed
+- Paths starting with `/` are assumed to be `earthengine-public` assets if no project is specified.
 
 ### changed
 - Storage operations can take a bucket as an optional parameter instead of always using the default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 
 ### added
 - Add `tree` function to recursively list assets in folder
+- Add `export`, `exportImage`, and `exportTable` to export assets to cloud storage
 
 ### changed
+- Update `download` to work for image collections
+- Update `download` to be able to recursively download image collections
 - Storage operations can take a bucket as an optional parameter instead of always using the default.
 - Storage operations will try to authenticate with default environment credentials the first time they are called.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.3.0 - 2021-05-13
+
+### fixed
+
+### changed
+- Storage operations can take a bucket as an optional parameter instead of always using the default.
+- Storage operations will try to authenticate with default environment credentials the first time they are called.
+
+
 ## v0.2.3 - 2021-02-05
 
 ### fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### fixed
 - Paths starting with `/` are assumed to be `earthengine-public` assets if no project is specified.
+- Use module logger level instead of root logger.
 
 ### added
 - Add `tree` function to recursively list assets in folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### fixed
 - Paths starting with `/` are assumed to be `earthengine-public` assets if no project is specified.
 
+### added
+- Add `tree` function to recursively list assets in folder
+
 ### changed
 - Storage operations can take a bucket as an optional parameter instead of always using the default.
 - Storage operations will try to authenticate with default environment credentials the first time they are called.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ eeUtil.downloadAsset('mycollection/myasset')
 
 __Install__
 
-`pip install -e git+https://github.com/fgassert/eeUtil.git#egg=eeUtil`
+`pip install eeUtil`
 
 __Develop__
 

--- a/eeUtil/eeutil.py
+++ b/eeUtil/eeutil.py
@@ -367,7 +367,7 @@ def waitForTasks(task_ids=[], timeout=3600):
         elapsed = time.time() - start
         finished = [_checkTaskCompleted(task) for task in task_ids]
         if all(finished):
-            logger.debug(f'Tasks {task_ids} completed after {elapsed}s')
+            logger.info(f'Tasks {task_ids} completed after {elapsed}s')
             return True
         time.sleep(5)
     logger.warning(f'Stopped waiting for {len(task_ids)} tasks after {timeout} seconds')
@@ -424,7 +424,7 @@ def ingest(gs_uri, asset, wait_timeout=None, bands=[], ingest_params={}):
             params['bands'] = bands
         request_id = ee.data.newTaskId()[0]
         task_id = ee.data.startIngestion(request_id, params, True)['id']
-    logger.debug(f"Ingesting {gs_uri} to {asset}: {task_id}")
+    logger.info(f"Ingesting {gs_uri} to {asset}: {task_id}")
     if wait_timeout is not None:
         waitForTask(task_id, wait_timeout)
 
@@ -657,7 +657,7 @@ def saveImage(image, assetId, dtype=None, pyramidingPolicy='mean', wait_timeout=
     if dtype:
         image = _cast(image, dtype)
 
-    logger.debug(f'Exporting image to {path}')
+    logger.info(f'Exporting image to {path}')
     task = ee.batch.Export.image.toAsset(**args)
     task.start()
     if wait_timeout is not None:
@@ -687,7 +687,7 @@ def findOrSaveImage(image, assetId, wait_timeout=None, **kwargs):
     description = kwargs.get('description', _getExportDescription(path))
     existing_task = next(filter(lambda t: t['description'] == description, getTasks(active=True)), None)
     if existing_task:
-        logger.debug(f'Task with description {description} already in progress, skipping export.')
+        logger.info(f'Task with description {description} already in progress, skipping export.')
         task_id = existing_task['id']
     else:
         task_id = saveImage(image, path, **kwargs)
@@ -745,14 +745,14 @@ def exportImage(image, blob, bucket=None, fileFormat='GeoTIFF', cloudOptimized=F
 
     exists = _getTileBlobs(uri)
     if exists and not overwrite:
-        logger.debug(f'{len(exists)} blobs matching {blob} exists, skipping export')
+        logger.info(f'{len(exists)} blobs matching {blob} exists, skipping export')
         return
 
     args = _getImageExportArgs(image, bucket, blob, cloudOptimized=cloudOptimized, **kwargs)
     task = ee.batch.Export.image.toCloudStorage(**args)
     task.start()
 
-    logger.debug(f'Exporting to {uri}')
+    logger.info(f'Exporting to {uri}')
     if wait_timeout is not None:
         waitForTask(task.id)
 
@@ -783,7 +783,7 @@ def exportTable(table, blob, bucket=None, fileFormat='GeoJSON',
     exists = gsbucket.exists(uri)
 
     if exists and not overwrite:
-        logger.debug(f'Blob matching {blobname} exists, skipping export')
+        logger.info(f'Blob matching {blobname} exists, skipping export')
         return
 
     args = {
@@ -796,7 +796,7 @@ def exportTable(table, blob, bucket=None, fileFormat='GeoJSON',
     task = ee.batch.Export.table.toCloudStorage(**args)
     task.start()
 
-    logger.debug(f'Exporting to {uri}')
+    logger.info(f'Exporting to {uri}')
     if wait_timeout is not None:
         waitForTask(task.id)
 
@@ -887,7 +887,6 @@ def download(assets, directory=None, gs_bucket=None, gs_prefix='', clean=True, r
             path = gsbucket.pathFromURI(_uri)
             fname = path[len(gs_prefix):].lstrip('/') if gs_prefix else path
             filenames.append(fname)
-            logger.debug('Downloading {uri}')
             gsbucket.download(_uri, fname, directory=directory)
             if clean:
                 gsbucket.remove(_uri)

--- a/eeUtil/eeutil.py
+++ b/eeUtil/eeutil.py
@@ -554,7 +554,7 @@ def _getAssetExportDims(proj, scale, bounds, bit_depth):
     total_bytes = x * y * bit_depth / 8
     if total_bytes > MAX_EXPORT_BYTES:
         x = y = 2**int(math.log(MAX_EXPORT_BYTES / (bit_depth/8), 2) / 2)
-        logging.warning(f'Export size (2^{math.log(total_bytes,2)}) more than 2^{math.log(MAX_EXPORT_BYTES,2)} bytes, dicing to {x}x{y} tiles')
+        logger.warning(f'Export size (2^{math.log(total_bytes,2)}) more than 2^{math.log(MAX_EXPORT_BYTES,2)} bytes, dicing to {x}x{y} tiles')
 
     return x,y
 
@@ -619,21 +619,20 @@ def _getImageSaveArgs(image, assetId, description=None, pyramidingPolicy='mean',
 def _cast(image, dtype):
     '''Cast an image to a data type'''
     return {
-        'uint8': image.uint8(),
-        'uint16': image.uint16(),
-        'uint32': image.uint32(),
-        'uint64': image.uint64(),
-        'int8': image.int8(),
-        'int16': image.int16(),
-        'int32': image.int32(),
-        'int64': image.int64(),
-        'byte': image.byte(),
-        'short': image.short(),
-        'int': image.int(),
-        'long': image.long(),
-        'float': image.float(),
-        'double': image.double()
-    }[dtype]
+        'uint8': image.uint8,
+        'uint16': image.uint16,
+        'uint32': image.uint32,
+        'int8': image.int8,
+        'int16': image.int16,
+        'int32': image.int32,
+        'int64': image.int64,
+        'byte': image.byte,
+        'short': image.short,
+        'int': image.int,
+        'long': image.long,
+        'float': image.float,
+        'double': image.double
+    }[dtype]()
 
 
 def saveImage(image, assetId, dtype=None, pyramidingPolicy='mean', wait_timeout=None, **kwargs):

--- a/eeUtil/eeutil.py
+++ b/eeUtil/eeutil.py
@@ -112,9 +112,9 @@ def formatDate(date):
 
 def getHome():
     '''Get user root directory'''
-    assetRoots = ee.data.getAssetRoots()
     project = ee._cloud_api_utils._cloud_api_user_project
     if project == ee.data.DEFAULT_CLOUD_API_USER_PROJECT:
+        assetRoots = ee.data.getAssetRoots()
         if not len(assetRoots):
             raise Exception(f"No available assets for provided credentials in project {project}")
         return assetRoots[0]['id']
@@ -869,7 +869,7 @@ def download(assets, directory=None, gs_bucket=None, gs_prefix='', clean=True, r
     filenames = []
 
     for uri in uris:
-        for _uri in _getTileBlobs(uri):
+        for _uri in gsbucket.getTileBlobs(uri):
             path = gsbucket.pathFromURI(_uri)
             fname = path[len(gs_prefix):].lstrip('/') if gs_prefix else path
             filenames.append(fname)

--- a/eeUtil/eeutil.py
+++ b/eeUtil/eeutil.py
@@ -848,10 +848,10 @@ def export(assets, bucket=None, prefix='', recursive=False,
         task = None
         if item['type'] in IMAGE_TYPES:
             image = ee.Image(item['name'])
-            task, uri = exportImage(image, bucket, blob, cloudOptimized=cloudOptimized, overwrite=overwrite, **kwargs)
+            task, uri = exportImage(image, blob, bucket, cloudOptimized=cloudOptimized, overwrite=overwrite, **kwargs)
         elif item['type'] in TABLE_TYPES:
             table = ee.FeatureCollection(item['name'])
-            task, uri = exportTable(table, bucket, blob, overwrite=overwrite, **kwargs)
+            task, uri = exportTable(table, blob, bucket, overwrite=overwrite, **kwargs)
         if task and uri:
             tasks.append(task)
             uris.append(uri)

--- a/eeUtil/eeutil.py
+++ b/eeUtil/eeutil.py
@@ -846,7 +846,7 @@ def export(assets, bucket=None, prefix='', recursive=False,
     uris = []
     for item, path in zip(infos, paths):
         blob = os.path.join(prefix, path)
-        task = None
+        result = None
         if item['type'] in IMAGE_TYPES:
             image = ee.Image(item['name'])
             result = exportImage(image, blob, bucket, cloudOptimized=cloudOptimized, overwrite=overwrite, **kwargs)

--- a/eeUtil/eeutil.py
+++ b/eeUtil/eeutil.py
@@ -191,7 +191,7 @@ def ls(path='', abspath=False, details=False, pageToken=None):
     for a in resp['assets']:
         a['name'] = a['name'] if abspath else os.path.basename(a['name'])
         yield (a if details else a['name'])
-    if resp['nextPageToken']:
+    if 'nextPageToken' in resp:
         for a in ls(path, abspath, details, pageToken=resp['nextPageToken']):
             yield a
 

--- a/eeUtil/eeutil.py
+++ b/eeUtil/eeutil.py
@@ -658,9 +658,9 @@ def saveImage(image, assetId, dtype=None, pyramidingPolicy='mean', wait_timeout=
     task = ee.batch.Export.image.toAsset(**args)
     task.start()
     if wait_timeout is not None:
-        waitForTask(task['id'], wait_timeout)
+        waitForTask(task.id, wait_timeout)
 
-    return task['id']
+    return task.id
 
 
 def findOrSaveImage(image, assetId, wait_timeout=None, **kwargs):
@@ -751,9 +751,9 @@ def exportImage(image, blob, bucket=None, fileFormat='GeoTIFF', cloudOptimized=F
 
     logging.debug(f'Exporting to {uri}')
     if wait_timeout is not None:
-        waitForTask(task)
+        waitForTask(task.id)
 
-    return task, uri
+    return task.id, uri
 
 
 
@@ -795,9 +795,9 @@ def exportTable(table, blob, bucket=None, fileFormat='GeoJSON',
 
     logging.debug(f'Exporting to {uri}')
     if wait_timeout is not None:
-        waitForTask(task)
+        waitForTask(task.id)
 
-    return task, uri
+    return task.id, uri
 
 
 def export(assets, bucket=None, prefix='', recursive=False,

--- a/eeUtil/gsbucket.py
+++ b/eeUtil/gsbucket.py
@@ -70,14 +70,20 @@ def isURI(path, bucket=''):
 
 def pathFromURI(uri):
     '''Returns blob path from URI'''
-    return fromUri(uri)[1]
+    return fromURI(uri)[1]
 
 
-def fromUri(uri):
+def fromURI(uri):
     '''Returns bucket name and blob path from URI'''
     if not isURI(uri):
         raise Exception(f'Path {uri} does not match gs://<bucket>/<blob>')
     return uri[6:].split('/', 1)
+
+
+def exists(uri):
+    '''check if blob exists'''
+    bucket, path = fromURI(uri)
+    return Bucket(bucket).blob(path).exists()
 
 
 def stage(files, prefix='', bucket=None):
@@ -116,7 +122,7 @@ def remove(gs_uris):
 
     paths = {}
     for uri in gs_uris:
-        bucket, path = fromUri(uri)
+        bucket, path = fromURI(uri)
         if bucket in paths:
             paths[bucket].append(path)
         else:

--- a/eeUtil/gsbucket.py
+++ b/eeUtil/gsbucket.py
@@ -29,7 +29,7 @@ def init(bucket=None, project=None, credentials=None):
     if bucket:
         _gsBucket = _gsClient.bucket(bucket)
         if not _gsBucket.exists():
-            logger.info('Bucket gs://{bucket} does not exist, creating')
+            logger.warning('Bucket gs://{bucket} does not exist, creating')
             _gsBucket.create()
 
 
@@ -108,7 +108,7 @@ def stage(files, prefix='', bucket=None):
     for f in files:
         path = os.path.join(prefix, os.path.basename(f))
         uri = asURI(path, bucket)
-        logger.debug(f'Uploading {f} to {uri}')
+        logger.info(f'Uploading {f} to {uri}')
         Bucket(bucket).blob(path).upload_from_filename(f)
         gs_uris.append(uri)
     return gs_uris
@@ -132,7 +132,7 @@ def remove(gs_uris):
             paths[bucket] = [path]
 
     for bucket, paths in paths:
-        logger.debug(f"Deleting {paths} from gs://{bucket}")
+        logger.info(f"Deleting {paths} from gs://{bucket}")
         Bucket(bucket).delete_blobs(paths, on_error=lambda x:x)
 
 
@@ -151,5 +151,5 @@ def download(gs_uri, filename=None, directory=None):
         filename = os.path.join(directory, filename)
     
     bucket, path = fromURI(gs_uri)
-    logger.debug(f"Downloading {gs_uri}")
+    logger.info(f"Downloading {gs_uri}")
     Bucket(bucket).blob(path).download_to_filename(filename)

--- a/eeUtil/gsbucket.py
+++ b/eeUtil/gsbucket.py
@@ -80,7 +80,7 @@ def fromURI(uri):
     '''Returns bucket name and blob path from URI'''
     if not isURI(uri):
         raise Exception(f'Path {uri} does not match gs://<bucket>/<blob>')
-    return uri[6:].split('/', 1)
+    return uri[5:].split('/', 1)
 
 
 def exists(uri):

--- a/eeUtil/gsbucket.py
+++ b/eeUtil/gsbucket.py
@@ -7,6 +7,9 @@ from . import eeutil
 # see https://github.com/googleapis/google-api-python-client/issues/299
 logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
 
+
+logger = logging.getLogger(__name__)
+
 # Unary client object
 _gsClient = None
 _gsBucket = None
@@ -26,7 +29,7 @@ def init(bucket=None, project=None, credentials=None):
     if bucket:
         _gsBucket = _gsClient.bucket(bucket)
         if not _gsBucket.exists():
-            logging.info('Bucket gs://{bucket} does not exist, creating')
+            logger.info('Bucket gs://{bucket} does not exist, creating')
             _gsBucket.create()
 
 
@@ -105,7 +108,7 @@ def stage(files, prefix='', bucket=None):
     for f in files:
         path = os.path.join(prefix, os.path.basename(f))
         uri = asURI(path, bucket)
-        logging.debug(f'Uploading {f} to {uri}')
+        logger.debug(f'Uploading {f} to {uri}')
         Bucket(bucket).blob(path).upload_from_filename(f)
         gs_uris.append(uri)
     return gs_uris
@@ -129,7 +132,7 @@ def remove(gs_uris):
             paths[bucket] = [path]
 
     for bucket, paths in paths:
-        logging.debug(f"Deleting {paths} from gs://{bucket}")
+        logger.debug(f"Deleting {paths} from gs://{bucket}")
         Bucket(bucket).delete_blobs(paths, on_error=lambda x:x)
 
 
@@ -148,5 +151,5 @@ def download(gs_uri, filename=None, directory=None):
         filename = os.path.join(directory, filename)
     
     bucket, path = fromURI(gs_uri)
-    logging.debug(f"Downloading {gs_uri}")
+    logger.debug(f"Downloading {gs_uri}")
     Bucket(bucket).blob(path).download_to_filename(filename)

--- a/eeUtil/gsbucket.py
+++ b/eeUtil/gsbucket.py
@@ -7,106 +7,140 @@ from . import eeutil
 # see https://github.com/googleapis/google-api-python-client/issues/299
 logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
 
-# Unary bucket object
+# Unary client object
+_gsClient = None
 _gsBucket = None
 
+
 def init(bucket=None, project=None, credentials=None):
-    '''Initalize google cloud storage bucket'''
+    '''Initialize Google Cloud Storage client and default bucket
+    
+    Args:
+        bucket (str): Default bucket to use
+        project (str): Authenticate to this GCP project
+        credentials (google.auth.credentials.Credentials): OAuth credentials
+    '''
+    global _gsClient
     global _gsBucket
-    if not bucket:
-        bucket = _getDefaultBucket()
-        logging.warning('No bucket provided, attempting to use default {}'.format(bucket))
-    gsClient = storage.Client(project, credentials=credentials) if project else storage.Client(credentials=credentials)
-    _gsBucket = gsClient.bucket(bucket)
-    if not _gsBucket.exists():
-        logging.info('Bucket {} does not exist, creating'.format(bucket))
-        _gsBucket.create()
+    _gsClient = storage.Client(project, credentials=credentials) if project else storage.Client(credentials=credentials)
+    if bucket:
+        _gsBucket = _gsClient.bucket(bucket)
+        if not _gsBucket.exists():
+            logging.info('Bucket gs://{bucket} does not exist, creating')
+            _gsBucket.create()
 
 
-def _getDefaultBucket():
-    '''Generate new bucket name'''
-    return 'eeutil-{}'.format(hash(eeutil.getHome()))
+def Client():
+    '''Returns Google Cloud Storage client'''
+    if not _gsClient:
+        init()
+    return _gsClient
 
 
-def getName():
-    '''Returns bucket name'''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
+def Bucket(bucket=None):
+    '''Returns authenticated Bucket object'''
+    bucket = _defaultBucketName(bucket)
+    return Client().bucket(bucket)
+
+
+def _defaultBucketName(bucket=None):
+    '''Returns default bucket name if bucket is None'''
+    if bucket is not None:
+        return bucket
+    if _gsBucket is None:
+        raise Exception('No default bucket, run eeUtil.init() to set a default bucket')
     return _gsBucket.name
 
 
 def asURI(path, bucket=None):
     '''Returns blob path as URI'''
-    if bucket is None:
-        bucket = getName()
-    return f"gs://{bucket}/{path}"
+    bucket = _defaultBucketName(bucket)
+    return f"gs://{os.path.join(bucket, path)}"
 
 
-def isURI(path):
-    '''Returns true if path is valid URI for this bucket'''
-    min_len = len(getName()) + 5
-    return len(path) > min_len and path[:min_len] == f'gs://{getName()}'
+def isURI(path, bucket=''):
+    '''Returns true if path is valid URI for bucket'''
+    start = f'gs://{bucket}'
+    return (
+        len(path) > len(start)+2 
+        and path[:len(start)] == start
+        and path[len(start)+1:].find('/') > -1
+    )
 
 
 def pathFromURI(uri):
     '''Returns blob path from URI'''
-    if isURI(uri):
-        return uri[6 + len(getName()):]
-    else:
-        raise Exception(f'Path {uri} does not match gs://{getName()}/<blob>')
+    return fromUri(uri)[1]
 
 
-def stage(files, prefix=''):
-    '''Upload files to GS with prefix'''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
+def fromUri(uri):
+    '''Returns bucket name and blob path from URI'''
+    if not isURI(uri):
+        raise Exception(f'Path {uri} does not match gs://<bucket>/<blob>')
+    return uri[6:].split('/', 1)
+
+
+def stage(files, prefix='', bucket=None):
+    '''Upload files to GCS
+
+    Uploads files to gs://<bucket>/<prefix>/<filename>
+
+    Args:
+        files (list, str): Filenames of local files to upload
+        prefix (str): Folder to upload to (prepended to file name)
+        bucket (str): GCS bucket to upload to
+
+    Returns:
+        list: URIs of uploaded files
+    '''
 
     files = (files,) if isinstance(files, str) else files
     gs_uris = []
     for f in files:
         path = os.path.join(prefix, os.path.basename(f))
-        uri = asURI(path)
+        uri = asURI(path, bucket)
         logging.debug(f'Uploading {f} to {uri}')
-        _gsBucket.blob(path).upload_from_filename(f)
+        Bucket(bucket).blob(path).upload_from_filename(f)
         gs_uris.append(uri)
     return gs_uris
 
 
 def remove(gs_uris):
     '''
-    Remove blobs from GS
+    Remove blobs from GCS
 
-    `gs_uris` must be full paths `gs://<bucket>/<blob>`
+    Args:
+        gs_uris (list, str): Full paths to blob(s) to remove `gs://<bucket>/<blob>`
     '''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
-
     gs_uris = (gs_uris,) if isinstance(gs_uris, str) else gs_uris
-    paths = []
-    for uri in gs_uris:
-        paths.append(pathFromURI(uri))
 
-    logging.debug(f"Deleting {paths} from gs://{getName()}")    
-    # on_error null function to ignore NotFound
-    _gsBucket.delete_blobs(paths, lambda x:x)
+    paths = {}
+    for uri in gs_uris:
+        bucket, path = fromUri(uri)
+        if bucket in paths:
+            paths[bucket].append(path)
+        else:
+            paths[bucket] = [path]
+
+    for bucket, paths in paths:
+        logging.debug(f"Deleting {paths} from gs://{bucket}")
+        Bucket(bucket).delete_blobs(paths, on_error=lambda x:x)
 
 
 def download(gs_uri, filename=None, directory=None):
     '''
-    Download blob from GS
+    Download blob from GCS
 
-    `gs_uri` must be full path `gs://<bucket>/<blob>`
-    `filename` name of local file to save defaults to remote name
-    `directory` save files to directory
+    Args:
+        gs_uri (string): full path to blob `gs://<bucket>/<blob>`
+        filename (string): name of local file to save (default: blob name)
+        directory (string): local directory to save files to
     '''
-    if not _gsBucket:
-        raise Exception('GS Bucket not initialized, run init()')
-
     if filename is None:
         filename = os.path.basename(gs_uri)
     if directory is not None:
         filename = os.path.join(directory, filename)
-
-    path = pathFromURI(gs_uri)
-    logging.debug(f"Downloading gs://{path}")
-    _gsBucket.blob(path).download_to_filename(filename)
+    
+    bucket, path = fromURI(gs_uri)
+    logging.debug(f"Downloading {gs_uri}")
+    Bucket(bucket).blob(path).download_to_filename(filename)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 
 setup(
     name='eeUtil',
-    version='0.2.3',
+    version='0.3.0',
     description='Python wrapper for easier data management on Google Earth Engine.',
     long_description=desc,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### fixed
- Paths starting with `/` are assumed to be `earthengine-public` assets if no project is specified.
- Use module logger level instead of root logger.

### added
- Add `tree` function to recursively list assets in folder
- Add `export`, `exportImage`, and `exportTable` to export assets to cloud storage
- Add `saveImage` and `findOrSaveImage` to export or cache images as assets

### changed
- Update `download` to work for feature collections
- Update `download` to be able to recursively download image collections
- Storage operations can take a bucket as an optional parameter instead of always using the default.
- Storage operations will try to authenticate with default environment credentials the first time they are called.

